### PR TITLE
Add mutual authentication using passphrases

### DIFF
--- a/cmd/hayate/main.go
+++ b/cmd/hayate/main.go
@@ -9,7 +9,9 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"bufio"
 
+	"hayate/internal/crypto"
 	"hayate/internal/network"
 	"hayate/internal/transfer"
 	"hayate/internal/tui"
@@ -91,12 +93,14 @@ func handleSend() {
 	compressFlag := sendCmd.String("compress", transfer.CompressAuto, "Compression mode: auto, always, never")
 	noTuiFlag := sendCmd.Bool("no-tui", false, "Disable interactive TUI")
 
+	passFlag := sendCmd.String("password", "", "Passphrase for mutual authentication")
+
 	_ = sendCmd.Parse(os.Args[2:])
 
 	args := sendCmd.Args()
 	if len(args) < 1 {
 		fmt.Println("Error: file path required")
-		fmt.Println("Usage: hayate send <file> [--peer ip:port] [--compress auto|always|never] [--no-tui]")
+		fmt.Println("Usage: hayate send <file> [--peer ip:port] [--compress auto|always|never] [--no-tui] [--password phrase]")
 		os.Exit(1)
 	}
 	compressMode, ok := transfer.NormalizeCompressionMode(*compressFlag)
@@ -123,14 +127,16 @@ func handleSend() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	password := *passFlag
+
 	if *noTuiFlag || !isatty.IsTerminal(os.Stdout.Fd()) {
-		runSenderHeadless(ctx, absPath, *peerFlag, *durationFlag, compressMode)
+		runSenderHeadless(ctx, absPath, *peerFlag, *durationFlag, compressMode, password)
 		return
 	}
 
 	localIP := network.GetLocalIP()
-	model := tui.NewModel(ctx, cancel, "send", absPath, *peerFlag, 0, localIP, "")
-	go runSenderOrchestrator(ctx, &model, absPath, *peerFlag, *durationFlag, compressMode)
+	model := tui.NewModel(ctx, cancel, "send", absPath, *peerFlag, 0, localIP, "", password)
+	go runSenderOrchestrator(ctx, &model, absPath, *peerFlag, *durationFlag, compressMode, password)
 
 	p := tea.NewProgram(model)
 	if _, err := p.Run(); err != nil {
@@ -145,6 +151,7 @@ func handleReceive() {
 	nameFlag := recvCmd.String("name", "", "mDNS display name")
 	noTuiFlag := recvCmd.Bool("no-tui", false, "Disable interactive TUI")
 	outputFlag := recvCmd.String("output", ".", "Download directory")
+	passFlag := recvCmd.String("password", "", "Passphrase for mutual authentication")
 
 	_ = recvCmd.Parse(os.Args[2:])
 
@@ -162,17 +169,25 @@ func handleReceive() {
 		}
 	}
 
+	password := *passFlag
+	if password == "" {
+		p, err := crypto.GeneratePassphrase(4)
+		if err == nil {
+			password = p
+		}
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	if *noTuiFlag || !isatty.IsTerminal(os.Stdout.Fd()) {
-		runReceiverHeadless(ctx, *portFlag, hostname, *outputFlag)
+		runReceiverHeadless(ctx, *portFlag, hostname, *outputFlag, password)
 		return
 	}
 
 	localIP := network.GetLocalIP()
-	model := tui.NewModel(ctx, cancel, "receive", "", "", *portFlag, localIP, hostname)
-	go runReceiverOrchestrator(ctx, &model, *portFlag, hostname, *outputFlag)
+	model := tui.NewModel(ctx, cancel, "receive", "", "", *portFlag, localIP, hostname, password)
+	go runReceiverOrchestrator(ctx, &model, *portFlag, hostname, *outputFlag, password)
 
 	p := tea.NewProgram(model)
 	if _, err := p.Run(); err != nil {
@@ -313,7 +328,7 @@ func formatBytes(b int64) string {
 
 // -- TUI Orchestrators --
 
-func runSenderOrchestrator(ctx context.Context, m *tui.Model, filePath string, peerAddr string, scanDuration time.Duration, compressMode string) {
+func runSenderOrchestrator(ctx context.Context, m *tui.Model, filePath string, peerAddr string, scanDuration time.Duration, compressMode string, password string) {
 	stat, err := os.Stat(filePath)
 	if err != nil {
 		m.MsgChan <- tui.ErrorMsg{Err: fmt.Errorf("stat: %w", err)}
@@ -344,6 +359,15 @@ func runSenderOrchestrator(ctx context.Context, m *tui.Model, filePath string, p
 		targetAddr = peerAddr
 	}
 
+	if password == "" {
+		select {
+		case pass := <-m.PasswordChan:
+			password = pass
+		case <-ctx.Done():
+			return
+		}
+	}
+
 	conn, err := network.DialPeer(ctx, targetAddr)
 	if err != nil {
 		m.MsgChan <- tui.ErrorMsg{Err: fmt.Errorf("connect: %w", err)}
@@ -358,7 +382,7 @@ func runSenderOrchestrator(ctx context.Context, m *tui.Model, filePath string, p
 	}
 	defer stream.Close()
 
-	key, err := transfer.EstablishSecureStreamSender(ctx, stream, filename, fileSize)
+	key, err := transfer.EstablishSecureStreamSender(ctx, stream, filename, fileSize, password)
 	if err != nil {
 		m.MsgChan <- tui.ErrorMsg{Err: fmt.Errorf("handshake: %w", err)}
 		return
@@ -391,7 +415,7 @@ func runSenderOrchestrator(ctx context.Context, m *tui.Model, filePath string, p
 	}
 }
 
-func runReceiverOrchestrator(ctx context.Context, m *tui.Model, listenPort int, advertisedName string, outputDir string) {
+func runReceiverOrchestrator(ctx context.Context, m *tui.Model, listenPort int, advertisedName string, outputDir string, password string) {
 	listener, err := network.CreateListener(listenPort)
 	if err != nil {
 		m.MsgChan <- tui.ErrorMsg{Err: fmt.Errorf("listener: %w", err)}
@@ -442,7 +466,7 @@ func runReceiverOrchestrator(ctx context.Context, m *tui.Model, listenPort int, 
 	}
 	defer stream.Close()
 
-	key, filename, fileSize, err := transfer.EstablishSecureStreamReceiver(ctx, stream)
+	key, filename, fileSize, err := transfer.EstablishSecureStreamReceiver(ctx, stream, password)
 	if err != nil {
 		m.MsgChan <- tui.ErrorMsg{Err: fmt.Errorf("handshake: %w", err)}
 		return
@@ -480,7 +504,7 @@ func runReceiverOrchestrator(ctx context.Context, m *tui.Model, listenPort int, 
 
 // -- Headless Flows --
 
-func runSenderHeadless(ctx context.Context, filePath string, peerAddr string, scanDuration time.Duration, compressMode string) {
+func runSenderHeadless(ctx context.Context, filePath string, peerAddr string, scanDuration time.Duration, compressMode string, password string) {
 	printBanner()
 
 	stat, err := os.Stat(filePath)
@@ -509,6 +533,13 @@ func runSenderHeadless(ctx context.Context, filePath string, peerAddr string, sc
 		targetAddr = peerAddr
 	}
 
+	if password == "" {
+		fmt.Print("  [*] Enter receiver's passphrase (or leave empty for unauthenticated): ")
+		reader := bufio.NewReader(os.Stdin)
+		pass, _ := reader.ReadString('\n')
+		password = strings.TrimSpace(pass)
+	}
+
 	step("Connecting to %s...", targetAddr)
 	conn, err := network.DialPeer(ctx, targetAddr)
 	if err != nil {
@@ -523,7 +554,7 @@ func runSenderHeadless(ctx context.Context, filePath string, peerAddr string, sc
 	defer stream.Close()
 
 	step("Performing cryptographic handshake...")
-	key, err := transfer.EstablishSecureStreamSender(ctx, stream, filename, fileSize)
+	key, err := transfer.EstablishSecureStreamSender(ctx, stream, filename, fileSize, password)
 	if err != nil {
 		fail("Handshake failed: %v", err)
 	}
@@ -580,8 +611,12 @@ func runSenderHeadless(ctx context.Context, filePath string, peerAddr string, sc
 	})
 }
 
-func runReceiverHeadless(ctx context.Context, listenPort int, advertisedName string, outputDir string) {
+func runReceiverHeadless(ctx context.Context, listenPort int, advertisedName string, outputDir string, password string) {
 	printBanner()
+
+	if password != "" {
+		step("Passphrase: %s", password)
+	}
 
 	listener, err := network.CreateListener(listenPort)
 	if err != nil {
@@ -628,7 +663,7 @@ func runReceiverHeadless(ctx context.Context, listenPort int, advertisedName str
 	defer stream.Close()
 
 	step("Performing cryptographic handshake...")
-	key, filename, fileSize, err := transfer.EstablishSecureStreamReceiver(ctx, stream)
+	key, filename, fileSize, err := transfer.EstablishSecureStreamReceiver(ctx, stream, password)
 	if err != nil {
 		fail("Handshake failed: %v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 )
 
 require (
+	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
+github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=

--- a/internal/crypto/auth.go
+++ b/internal/crypto/auth.go
@@ -1,0 +1,79 @@
+package crypto
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+	"strings"
+
+	"golang.org/x/crypto/argon2"
+)
+
+var wordlist = []string{
+	"apple", "bacon", "cabin", "dance", "eagle", "fable", "ghost", "habit",
+	"ice", "juice", "kite", "lemon", "magic", "ninja", "ocean", "piano",
+	"queen", "robot", "salad", "tiger", "uncle", "virus", "wagon", "zebra",
+	"actor", "beach", "camel", "delta", "earth", "flame", "giant", "honey",
+	"image", "jelly", "koala", "laser", "mango", "novel", "onion", "panda",
+	"quiet", "radar", "snake", "train", "union", "vocal", "water", "yield",
+	"alarm", "bread", "candy", "dream", "early", "field", "glass", "happy",
+	"index", "jump", "king", "light", "mouse", "night", "orbit", "plant",
+	"quick", "river", "smile", "table", "urban", "voice", "wheat", "young",
+	"alien", "brick", "cause", "drill", "eager", "flash", "globe", "heart",
+	"iron", "judge", "knife", "limit", "music", "noise", "order", "paper",
+	"quote", "rock", "smoke", "taste", "usage", "volts", "wheel", "youth",
+	"anger", "brush", "chain", "drink", "empty", "flock", "glory", "heavy",
+	"ivory", "juice", "knock", "local", "naked", "north", "organ", "party",
+	"radio", "rough", "solid", "theme", "usher", "vowel", "white", "zebra",
+	"angle", "build", "chair", "drive", "enemy", "floor", "glove", "hedge",
+	"jeans", "joint", "known", "logic", "nerve", "nurse", "other", "peace",
+	"reach", "round", "sound", "thick", "valid", "watch", "whole", "zonal",
+	"animal", "bunch", "chalk", "drone", "entry", "fluid", "grace", "hello",
+	"jewel", "joker", "label", "loose", "never", "nylon", "outer", "pearl",
+	"react", "route", "space", "thing", "value", "water", "width", "zones",
+	"ankle", "buyer", "charm", "drown", "equal", "focus", "grain", "hinge",
+	"jumbo", "jolly", "labor", "lower", "newly", "oasis", "owner", "phase",
+	"ready", "royal", "speed", "think", "valve", "wealth", "woman", "zoom",
+	"apple", "cable", "chart", "drum", "error", "force", "grand", "hobby",
+	"jump", "joyful", "laced", "lucky", "night", "ocean", "paint", "phone",
+	"rebel", "rural", "spend", "third", "vault", "weapon", "world", "zone",
+	"armor", "cacao", "chase", "drunk", "event", "forge", "grant", "honor",
+	"jury", "judge", "lance", "lunar", "noble", "offer", "panel", "photo",
+	"recap", "safer", "spice", "thorn", "vegan", "weary", "worry", "zinc",
+	"arrow", "cache", "cheap", "dryer", "exact", "forth", "grasp", "horse",
+	"just", "juice", "large", "lunch", "noise", "often", "panic", "piece",
+	"relax", "saint", "spike", "those", "venom", "weave", "worse", "zero",
+	"asset", "caddy", "check", "duck", "exist", "forty", "grass", "hotel",
+	"keen", "jelly", "laser", "lurch", "north", "older", "paper", "pilot",
+	"relay", "salad", "spill", "three", "venue", "wedge", "worth", "zeal",
+	"audio", "cadet", "cheek", "dummy", "extra", "forum", "grave", "hound",
+	"keep", "joker", "latch", "lured", "notch", "olive", "parka", "pitch",
+	"relic", "salon", "spine", "throw", "verge", "weigh", "would", "zest",
+	"audit", "cagey", "cheer", "dump", "fable", "found", "great", "house",
+	"kept", "jumbo", "later", "lurid", "novel", "omega", "party", "pivot",
+	"remit", "salsa", "spite", "thumb", "verse", "weird", "wound", "zone",
+}
+
+func GeneratePassphrase(numWords int) (string, error) {
+	if numWords <= 0 {
+		numWords = 4
+	}
+	words := make([]string, numWords)
+	for i := 0; i < numWords; i++ {
+		var b [2]byte
+		if _, err := rand.Read(b[:]); err != nil {
+			return "", err
+		}
+		idx := int(binary.BigEndian.Uint16(b[:])) % len(wordlist)
+		words[i] = wordlist[idx]
+	}
+	return strings.Join(words, "-"), nil
+}
+
+func DeriveKEK(passphrase string, salt []byte) []byte {
+	time := uint32(2)
+	memory := uint32(64 * 1024)
+	threads := uint8(2)
+	keyLen := uint32(32)
+
+	return argon2.IDKey([]byte(passphrase), salt, time, memory, threads, keyLen)
+}

--- a/internal/crypto/crypto_test.go
+++ b/internal/crypto/crypto_test.go
@@ -131,3 +131,36 @@ func BenchmarkEncryptInPlace(b *testing.B) {
 		_, _ = EncryptInPlace(aead, ng, plaintext, dst)
 	}
 }
+
+func TestGeneratePassphrase(t *testing.T) {
+	passphrase, err := GeneratePassphrase(4)
+	if err != nil {
+		t.Fatalf("failed to generate passphrase: %v", err)
+	}
+	words := bytes.Split([]byte(passphrase), []byte("-"))
+	if len(words) != 4 {
+		t.Fatalf("expected 4 words, got %d", len(words))
+	}
+}
+
+func TestDeriveKEK(t *testing.T) {
+	salt := []byte("test-salt-123456")
+	passphrase := "apple-bacon-cabin-dance"
+
+	key1 := DeriveKEK(passphrase, salt)
+	key2 := DeriveKEK(passphrase, salt)
+
+	if !bytes.Equal(key1, key2) {
+		t.Fatal("DeriveKEK should be deterministic for same inputs")
+	}
+
+	key3 := DeriveKEK("different-passphrase", salt)
+	if bytes.Equal(key1, key3) {
+		t.Fatal("DeriveKEK should differ for different passphrases")
+	}
+
+	key4 := DeriveKEK(passphrase, []byte("different-salt"))
+	if bytes.Equal(key1, key4) {
+		t.Fatal("DeriveKEK should differ for different salts")
+	}
+}

--- a/internal/transfer/transfer.go
+++ b/internal/transfer/transfer.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"crypto/rand"
 	"runtime"
 	"sync"
 
@@ -539,19 +540,56 @@ func recvWorker(ctx context.Context, wg *sync.WaitGroup, aead cipher.AEAD, jobs 
 }
 
 // EstablishSecureStreamSender performs ephemeral key exchange and sends file metadata.
-func EstablishSecureStreamSender(ctx context.Context, stream *quic.Stream, filename string, fileSize int64) ([]byte, error) {
+func EstablishSecureStreamSender(ctx context.Context, stream *quic.Stream, filename string, fileSize int64, passphrase string) ([]byte, error) {
 	priv, pub, err := crypto.GenerateEphemeralKeyPair()
 	if err != nil {
 		return nil, fmt.Errorf("generating keypair: %w", err)
 	}
 
-	if _, err := stream.Write(pub); err != nil {
-		return nil, fmt.Errorf("sending public key: %w", err)
-	}
+	var peerPub []byte
 
-	peerPub := make([]byte, 32)
-	if _, err := io.ReadFull(stream, peerPub); err != nil {
-		return nil, fmt.Errorf("reading peer public key: %w", err)
+	if passphrase != "" {
+		salt := make([]byte, 16)
+		if _, err := io.ReadFull(rand.Reader, salt); err != nil {
+			return nil, fmt.Errorf("generating salt: %w", err)
+		}
+		
+		if _, err := stream.Write(append([]byte{0x01}, salt...)); err != nil {
+			return nil, fmt.Errorf("sending auth header: %w", err)
+		}
+
+		kek := crypto.DeriveKEK(passphrase, salt)
+		encPub, err := crypto.Encrypt(kek, pub)
+		if err != nil {
+			return nil, fmt.Errorf("encrypting pubkey: %w", err)
+		}
+		
+		if _, err := stream.Write(encPub); err != nil {
+			return nil, fmt.Errorf("sending encrypted pubkey: %w", err)
+		}
+
+		encPeerPub := make([]byte, 60)
+		if _, err := io.ReadFull(stream, encPeerPub); err != nil {
+			return nil, fmt.Errorf("reading encrypted peer pubkey: %w", err)
+		}
+		
+		peerPub, err = crypto.Decrypt(kek, encPeerPub)
+		if err != nil {
+			return nil, fmt.Errorf("invalid passphrase or handshake failed: %w", err)
+		}
+	} else {
+		if _, err := stream.Write([]byte{0x00}); err != nil {
+			return nil, fmt.Errorf("sending plain header: %w", err)
+		}
+
+		if _, err := stream.Write(pub); err != nil {
+			return nil, fmt.Errorf("sending public key: %w", err)
+		}
+
+		peerPub = make([]byte, 32)
+		if _, err := io.ReadFull(stream, peerPub); err != nil {
+			return nil, fmt.Errorf("reading peer public key: %w", err)
+		}
 	}
 
 	key, err := crypto.DeriveSharedSecret(priv, peerPub)
@@ -589,19 +627,65 @@ func EstablishSecureStreamSender(ctx context.Context, stream *quic.Stream, filen
 }
 
 // EstablishSecureStreamReceiver performs ephemeral key exchange and receives file metadata.
-func EstablishSecureStreamReceiver(ctx context.Context, stream *quic.Stream) ([]byte, string, int64, error) {
+func EstablishSecureStreamReceiver(ctx context.Context, stream *quic.Stream, passphrase string) ([]byte, string, int64, error) {
 	priv, pub, err := crypto.GenerateEphemeralKeyPair()
 	if err != nil {
 		return nil, "", 0, fmt.Errorf("generating keypair: %w", err)
 	}
 
-	peerPub := make([]byte, 32)
-	if _, err := io.ReadFull(stream, peerPub); err != nil {
-		return nil, "", 0, fmt.Errorf("reading peer public key: %w", err)
+	flag := make([]byte, 1)
+	if _, err := io.ReadFull(stream, flag); err != nil {
+		return nil, "", 0, fmt.Errorf("reading auth header: %w", err)
 	}
 
-	if _, err := stream.Write(pub); err != nil {
-		return nil, "", 0, fmt.Errorf("sending public key: %w", err)
+	var peerPub []byte
+
+	if flag[0] == 0x01 {
+		if passphrase == "" {
+			return nil, "", 0, fmt.Errorf("sender requires a passphrase, but none was provided")
+		}
+
+		salt := make([]byte, 16)
+		if _, err := io.ReadFull(stream, salt); err != nil {
+			return nil, "", 0, fmt.Errorf("reading salt: %w", err)
+		}
+
+		kek := crypto.DeriveKEK(passphrase, salt)
+		
+		encPeerPub := make([]byte, 60)
+		if _, err := io.ReadFull(stream, encPeerPub); err != nil {
+			return nil, "", 0, fmt.Errorf("reading encrypted peer pubkey: %w", err)
+		}
+		
+		peerPub, err = crypto.Decrypt(kek, encPeerPub)
+		if err != nil {
+			return nil, "", 0, fmt.Errorf("invalid passphrase or handshake failed: %w", err)
+		}
+
+		encPub, err := crypto.Encrypt(kek, pub)
+		if err != nil {
+			return nil, "", 0, fmt.Errorf("encrypting pubkey: %w", err)
+		}
+		
+		if _, err := stream.Write(encPub); err != nil {
+			return nil, "", 0, fmt.Errorf("sending encrypted pubkey: %w", err)
+		}
+
+	} else if flag[0] == 0x00 {
+		if passphrase != "" {
+			return nil, "", 0, fmt.Errorf("receiver requires a passphrase, but sender did not use one")
+		}
+
+		peerPub = make([]byte, 32)
+		if _, err := io.ReadFull(stream, peerPub); err != nil {
+			return nil, "", 0, fmt.Errorf("reading peer public key: %w", err)
+		}
+
+		if _, err := stream.Write(pub); err != nil {
+			return nil, "", 0, fmt.Errorf("sending public key: %w", err)
+		}
+	} else {
+		return nil, "", 0, fmt.Errorf("unknown handshake flag: 0x%02x", flag[0])
 	}
 
 	key, err := crypto.DeriveSharedSecret(priv, peerPub)

--- a/internal/transfer/transfer_test.go
+++ b/internal/transfer/transfer_test.go
@@ -150,3 +150,81 @@ func TestFileTransferPipeline(t *testing.T) {
 		t.Fatal("Destination file bytes do not match source file bytes!")
 	}
 }
+
+func TestSecureStreamHandshake(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	listener, err := network.CreateListener(0)
+	if err != nil {
+		t.Fatalf("Failed to create QUIC listener: %v", err)
+	}
+	defer listener.Close()
+
+	_, portStr, _ := net.SplitHostPort(listener.Addr().String())
+	addr := net.JoinHostPort("127.0.0.1", portStr)
+
+	testCases := []struct {
+		name         string
+		senderPass   string
+		receiverPass string
+		expectErr    bool
+	}{
+		{"NoAuth", "", "", false},
+		{"ValidAuth", "apple-bacon-cabin-dance", "apple-bacon-cabin-dance", false},
+		{"WrongAuth", "apple-bacon-cabin-dance", "different-passphrase", true},
+		{"SenderOnlyAuth", "apple-bacon-cabin-dance", "", true},
+		{"ReceiverOnlyAuth", "", "apple-bacon-cabin-dance", true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			recvErrChan := make(chan error, 1)
+			go func() {
+				conn, err := listener.Accept(ctx)
+				if err != nil {
+					recvErrChan <- err
+					return
+				}
+				defer conn.CloseWithError(0, "done")
+				stream, err := conn.AcceptStream(ctx)
+				if err != nil {
+					recvErrChan <- err
+					return
+				}
+				defer stream.Close()
+				_, _, _, err = EstablishSecureStreamReceiver(ctx, stream, tc.receiverPass)
+				recvErrChan <- err
+			}()
+
+			clientConn, err := network.DialPeer(ctx, addr)
+			if err != nil {
+				t.Fatalf("Client failed to dial: %v", err)
+			}
+			clientStream, err := clientConn.OpenStreamSync(ctx)
+			if err != nil {
+				t.Fatalf("Client failed to open stream: %v", err)
+			}
+
+			_, sendErr := EstablishSecureStreamSender(ctx, clientStream, "test.txt", 1024, tc.senderPass)
+			recvErr := <-recvErrChan
+
+			clientStream.Close()
+			clientConn.CloseWithError(0, "done")
+
+			if tc.expectErr {
+				if sendErr == nil && recvErr == nil {
+					t.Fatalf("expected error, but got none")
+				}
+			} else {
+				if sendErr != nil {
+					t.Fatalf("unexpected sender error: %v", sendErr)
+				}
+				if recvErr != nil {
+					t.Fatalf("unexpected receiver error: %v", recvErr)
+				}
+			}
+		})
+	}
+}
+

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -11,6 +11,7 @@ import (
 	"hayate/internal/transfer"
 
 	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/muesli/termenv"
@@ -21,6 +22,7 @@ type State int
 const (
 	StateDiscover State = iota
 	StateSelectPeer
+	StatePasswordPrompt
 	StateHandshake
 	StateTransferring
 	StateCompleted
@@ -199,33 +201,54 @@ type Model struct {
 	hash         string
 	compSize     int64
 	isSend       bool
+	password     string
 
 	spinner          spinner.Model
+	textInput        textinput.Model
 	MsgChan          chan tea.Msg
 	SelectedPeerChan chan network.Peer
+	PasswordChan     chan string
 	Ctx              context.Context
 	Cancel           context.CancelFunc
 }
 
-func NewModel(ctx context.Context, cancel context.CancelFunc, mode string, filePath string, peerAddr string, port int, localIP string, advertised string) Model {
+func NewModel(ctx context.Context, cancel context.CancelFunc, mode string, filePath string, peerAddr string, port int, localIP string, advertised string, password string) Model {
 	s := spinner.New()
 	s.Spinner = spinner.Line
 	s.Style = lipgloss.NewStyle().Foreground(cyan)
 
+	ti := textinput.New()
+	ti.Placeholder = "Enter 4-word passphrase (or empty for none)"
+	ti.Focus()
+	ti.CharLimit = 128
+	ti.Width = 40
+
+	initialState := StateDiscover
+	if mode == "send" && peerAddr != "" {
+		if password == "" {
+			initialState = StatePasswordPrompt
+		} else {
+			initialState = StateHandshake
+		}
+	}
+
 	return Model{
 		Mode:             mode,
-		state:            StateDiscover,
+		state:            initialState,
 		filePath:         filePath,
 		peerAddr:         peerAddr,
 		port:             port,
 		localIP:          localIP,
 		localAddr:        localIP,
 		advertised:       advertised,
+		password:         password,
 		width:            80,
 		asciiOnly:        !termenv.HasDarkBackground() || termenv.ColorProfile() == termenv.Ascii,
 		spinner:          s,
+		textInput:        ti,
 		MsgChan:          make(chan tea.Msg, 64),
 		SelectedPeerChan: make(chan network.Peer, 1),
+		PasswordChan:     make(chan string, 1),
 		Ctx:              ctx,
 		Cancel:           cancel,
 	}
@@ -259,6 +282,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 	case tea.KeyMsg:
+		if m.state == StatePasswordPrompt && msg.String() != "enter" && msg.String() != "ctrl+c" && msg.String() != "esc" {
+			var cmd tea.Cmd
+			m.textInput, cmd = m.textInput.Update(msg)
+			return m, cmd
+		}
+
 		switch msg.String() {
 		case "ctrl+c", "esc":
 			m.Cancel()
@@ -278,12 +307,23 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "enter":
 			if m.state == StateSelectPeer && len(m.peers) > 0 {
 				selected := m.peers[m.selectedIdx]
-				m.state = StateHandshake
 				m.peerAddr = network.FormatAddress(selected.IP, selected.Port)
 				select {
 				case m.SelectedPeerChan <- selected:
 				default:
 				}
+				if m.password == "" {
+					m.state = StatePasswordPrompt
+				} else {
+					m.state = StateHandshake
+				}
+			} else if m.state == StatePasswordPrompt {
+				m.password = strings.TrimSpace(m.textInput.Value())
+				select {
+				case m.PasswordChan <- m.password:
+				default:
+				}
+				m.state = StateHandshake
 			} else if m.state == StateCompleted || m.state == StateError {
 				return m, tea.Quit
 			}
@@ -292,7 +332,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case spinner.TickMsg:
 		var cmd tea.Cmd
 		m.spinner, cmd = m.spinner.Update(msg)
-		cmds = append(cmds, cmd)
+		var tiCmd tea.Cmd
+		m.textInput, tiCmd = m.textInput.Update(msg)
+		cmds = append(cmds, cmd, tiCmd)
 
 	case PeerDiscoveredMsg:
 		m.peers = msg
@@ -392,6 +434,8 @@ func (m Model) View() string {
 		s.WriteString(m.viewDiscover())
 	case StateSelectPeer:
 		s.WriteString(m.viewSelectPeer())
+	case StatePasswordPrompt:
+		s.WriteString(m.viewPasswordPrompt())
 	case StateHandshake:
 		s.WriteString(m.viewHandshake())
 	case StateTransferring:
@@ -443,7 +487,14 @@ func (m Model) viewDiscover() string {
 		if m.advertised != "" {
 			s.WriteString(fmt.Sprintf("  (advertised as %s)", m.advertised))
 		}
-		s.WriteString("\n")
+		s.WriteString("\n\n")
+		if m.password != "" {
+			pw := m.password
+			if !m.asciiOnly {
+				pw = hashStyle.Render(pw)
+			}
+			s.WriteString("  Passphrase: " + pw + "\n")
+		}
 	}
 
 	s.WriteString(hint("Esc to abort"))
@@ -479,6 +530,15 @@ func (m Model) viewSelectPeer() string {
 
 	s.WriteString(tableHeaderStyle.Render("    "+strings.Repeat("-", nameW+addrW+14)) + "\n")
 	s.WriteString(hint("j/k or Up/Down to navigate  |  Enter to select  |  Esc to cancel"))
+	return s.String()
+}
+
+func (m Model) viewPasswordPrompt() string {
+	var s strings.Builder
+	s.WriteString(sectionStyle.Render("[ AUTHENTICATION ]") + "\n\n")
+	s.WriteString("  Enter receiver's passphrase (leave empty if none):\n\n")
+	s.WriteString("  " + m.textInput.View() + "\n\n")
+	s.WriteString(hint("Enter to submit  |  Esc to cancel"))
 	return s.String()
 }
 


### PR DESCRIPTION
I added mutual authentication passwords to secure file transfers. Because files are being sent over local networks, anyone else on that same network could potentially intercept or receive those files. To prevent this, the app now generates a random password... the sender must type that password in to send the file, and the receiver must also type that exact password in order to access the files.